### PR TITLE
ConnectionClosedEvent to only consider success for closure code 1000

### DIFF
--- a/src/common.speech/ServiceRecognizerBase.ts
+++ b/src/common.speech/ServiceRecognizerBase.ts
@@ -173,10 +173,7 @@ export abstract class ServiceRecognizerBase implements IDisposable {
         this.connectionEvents.attach((connectionEvent: ConnectionEvent): void => {
             if (connectionEvent.name === "ConnectionClosedEvent") {
                 const connectionClosedEvent = connectionEvent as ConnectionClosedEvent;
-                if (connectionClosedEvent.statusCode === 1003 ||
-                    connectionClosedEvent.statusCode === 1007 ||
-                    connectionClosedEvent.statusCode === 1002 ||
-                    connectionClosedEvent.statusCode === 4000 ||
+                if (connectionClosedEvent.statusCode !== 1000 ||
                     this.privRequestSession.numConnectionAttempts > this.privRecognizerConfig.maxRetryCount
                 ) {
                     void this.cancelRecognitionLocal(CancellationReason.Error,


### PR DESCRIPTION
Hello,

this attempt to fix [#896](https://github.com/microsoft/cognitive-services-speech-sdk-js/issues/896)
This is assuming that statusCode 1000 is the only success code and any other could be considered an error.
 